### PR TITLE
Remove unneeded delay on file creation on newer versions

### DIFF
--- a/src/core/Templater.ts
+++ b/src/core/Templater.ts
@@ -2,6 +2,7 @@ import {
     MarkdownPostProcessorContext,
     MarkdownView,
     normalizePath,
+    requireApiVersion,
     TAbstractFile,
     TFile,
     TFolder,
@@ -396,8 +397,11 @@ export class Templater {
 
         // TODO: find a better way to do this
         // Currently, I have to wait for the daily note plugin to add the file content before replacing
-        // Not a problem with Calendar however since it creates the file with the existing content
-        await delay(300);
+        // Not a problem with Calendar or after version 1.0 of Obsidian however since it creates the file with the existing content
+        // https://forum.obsidian.md/t/why-i-need-to-wait-a-random-amount-of-time-after-creating-a-file-with-teplater/66066/8
+        if (!requireApiVersion("1.0")) {
+            await delay(300);
+        }
 
         if (
             file.stat.size == 0 &&


### PR DESCRIPTION
Remove unneeded delay on file creation after version 1.0 of Obsidian.

> I believe that templater can remove that 300ms delay now. The reason was actually a problem in Obsidian core that was fixed a long time ago.
> Basically, the daily notes core plugin would create an empty file, then modify the empty file with your daily note template.
> The issue was that the ‘created’ event was fired before the daily note template was applied, so Templater needed to work around that issue.
> I think that hasn’t been a problem since around 1.0 of Obsidian. Now all the core plugins create the file with the contents already applied in a single filesystem call.

Liam C., Obsidian Team
https://forum.obsidian.md/t/why-i-need-to-wait-a-random-amount-of-time-after-creating-a-file-with-teplater/66066/8